### PR TITLE
Add Linux build support

### DIFF
--- a/src/LuminaSupplemental.Cmd/LuminaSupplemental.Cmd.csproj
+++ b/src/LuminaSupplemental.Cmd/LuminaSupplemental.Cmd.csproj
@@ -14,6 +14,9 @@
         <DalamudLibPath>$(AppData)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))'">
+        <DalamudLibPath>$(DALAMUD_HOME)/</DalamudLibPath>
+    </PropertyGroup>
 
     <ItemGroup>
         <Reference Include="Lumina">

--- a/src/LuminaSupplemental.Excel/LuminaSupplemental.Excel.csproj
+++ b/src/LuminaSupplemental.Excel/LuminaSupplemental.Excel.csproj
@@ -31,6 +31,9 @@
         <DalamudLibPath>$(AppData)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))'">
+        <DalamudLibPath>$(DALAMUD_HOME)/</DalamudLibPath>
+    </PropertyGroup>
 
     <ItemGroup>
         <Reference Include="Lumina">

--- a/src/LuminaSupplemental.SpaghettiGenerator/LuminaSupplemental.SpaghettiGenerator.csproj
+++ b/src/LuminaSupplemental.SpaghettiGenerator/LuminaSupplemental.SpaghettiGenerator.csproj
@@ -9,6 +9,9 @@
         <DalamudLibPath>$(AppData)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))'">
+        <DalamudLibPath>$(DALAMUD_HOME)/</DalamudLibPath>
+    </PropertyGroup>
 
     <ItemGroup>
       <Content Include="../GarlandTools/Supplemental/FFXIV Data - Items.tsv" CopyToOutputDirectory="Always" />


### PR DESCRIPTION
Adds Linux support via the `DALAMUD_HOME` environment variable. I needed this fix to build on Linux in GA. I used the same configuration that plugins use.