### PR TITLE
`DungeonChest` rename ChestId and add DungeonBossId

### DIFF
--- a/src/LuminaSupplemental.Excel/Model/DungeonChest.cs
+++ b/src/LuminaSupplemental.Excel/Model/DungeonChest.cs
@@ -24,20 +24,22 @@ namespace LuminaSupplemental.Excel.Model
         [Name("ContentFinderConditionId")] public uint ContentFinderConditionId { get; set; }
         [Name("MapId")] public uint MapId { get; set; }
         [Name("TerritoryTypeId")] public uint TerritoryTypeId { get; set; }
-        [Name("ChestId")] public uint ChestId { get; set; }
+        [Name("TreasureId")] public uint TreasureId { get; set; }
+        [Name("DungeonBossId")] public uint DungeonBossId { get; set; }
 
         public RowRef< ContentFinderCondition > ContentFinderCondition;
         public RowRef< Map > Map;
         public RowRef< TerritoryType > TerritoryType;
 
-        public DungeonChest(uint rowId, byte chestNo,uint contentFinderConditionId, uint mapId, uint territoryTypeId, uint chestId )
+        public DungeonChest(uint rowId, byte chestNo,uint contentFinderConditionId, uint mapId, uint territoryTypeId, uint treasureId, uint dungeonBossId = 0 )
         {
             RowId = rowId;
             ChestNo = chestNo;
             ContentFinderConditionId = contentFinderConditionId;
             MapId = mapId;
             TerritoryTypeId = territoryTypeId;
-            ChestId = chestId;
+            TreasureId = treasureId;
+            DungeonBossId = dungeonBossId;
         }
 
         public DungeonChest()
@@ -52,7 +54,8 @@ namespace LuminaSupplemental.Excel.Model
             ContentFinderConditionId = uint.Parse( lineData[ 2 ] );
             MapId = uint.Parse( lineData[ 3 ] );
             TerritoryTypeId = uint.Parse( lineData[ 4 ] );
-            this.ChestId = uint.Parse( lineData[ 5 ] );
+            TreasureId = uint.Parse( lineData[ 5 ] );
+            DungeonBossId = uint.Parse( lineData[ 6 ] );
         }
 
         public string[] ToCsv()
@@ -64,7 +67,8 @@ namespace LuminaSupplemental.Excel.Model
                 ContentFinderConditionId.ToString(),
                 MapId.ToString(),
                 TerritoryTypeId.ToString(),
-                this.ChestId.ToString(),
+                TreasureId.ToString(),
+                DungeonBossId.ToString(),
             };
             return data.ToArray();
         }

--- a/src/LuminaSupplemental.SpaghettiGenerator/Steps/DungeonChestStep.cs
+++ b/src/LuminaSupplemental.SpaghettiGenerator/Steps/DungeonChestStep.cs
@@ -25,6 +25,8 @@ public partial class DungeonChestStep : GeneratorStep
 
     public override string Name => "Dungeon Chests";
 
+    public override List<Type>? PrerequisiteSteps => [typeof(DungeonChestItemStep), typeof(DungeonBossChestStep), typeof(DungeonBossStep)];
+
     public DungeonChestStep(DataCacher dataCacher)
     {
         this.dataCacher = dataCacher;
@@ -32,9 +34,9 @@ public partial class DungeonChestStep : GeneratorStep
 
     public override List<ICsv> Run(Dictionary<Type, List<ICsv>> stepData)
     {
-        List<DungeonChest> items = new();
-        items.AddRange(this.ProcessChests());
-        return [..items.Select(c => c)];
+        var chests = this.ProcessChests();
+        this.AssignBossIds(chests, stepData);
+        return [..chests.Select(c => c)];
     }
 
     private List<DungeonChest> ProcessChests()
@@ -64,7 +66,7 @@ public partial class DungeonChestStep : GeneratorStep
                                     ContentFinderConditionId = duty.Id,
                                     MapId = chest.MapId,
                                     TerritoryTypeId = chest.TerritoryId,
-                                    ChestId = chest.Id
+                                    TreasureId = chest.Id
                                 });
                             chestId++;
                         }
@@ -74,5 +76,38 @@ public partial class DungeonChestStep : GeneratorStep
         }
 
         return chests;
+    }
+
+    private void AssignBossIds(List<DungeonChest> chests, Dictionary<Type, List<ICsv>> stepData)
+    {
+        var chestItemsByChestId = stepData[typeof(DungeonChestItemStep)]
+            .Cast<DungeonChestItem>()
+            .GroupBy(i => i.ChestId)
+            .ToDictionary(g => g.Key, g => g.Select(i => i.ItemId).ToHashSet());
+
+        var bossChestGroups = stepData[typeof(DungeonBossChestStep)]
+            .Cast<DungeonBossChest>()
+            .GroupBy(b => (b.ContentFinderConditionId, b.FightNo))
+            .ToDictionary(g => g.Key, g => g.Select(b => b.ItemId).ToHashSet());
+
+        var bossesByFight = stepData[typeof(DungeonBossStep)]
+            .Cast<DungeonBoss>()
+            .GroupBy(b => (b.ContentFinderConditionId, b.FightNo))
+            .ToDictionary(g => g.Key, g => g.Min(b => b.RowId));
+
+        foreach (var chest in chests)
+        {
+            if (!chestItemsByChestId.TryGetValue(chest.RowId, out var itemIds))
+                continue;
+
+            var matchedFight = bossChestGroups
+                .Where(kvp => kvp.Key.ContentFinderConditionId == chest.ContentFinderConditionId)
+                .Where(kvp => kvp.Value.SetEquals(itemIds))
+                .Select(kvp => kvp.Key)
+                .FirstOrDefault();
+
+            if (bossesByFight.TryGetValue(matchedFight, out var bossId))
+                chest.DungeonBossId = bossId;
+        }
     }
 }


### PR DESCRIPTION
not sure if you ever do column name changes (or if there's way to obsolete) but that one's very confusing since DungeonChestItem also has it and they're completely unrelated. It's the Treasure excel sheet rowid.

For the DungeonBosstId, I just get all the items within a given cfc's fightno and see if any DungeonChest matches that. The only real limitation is for the few DungeonBosses that have multiple entries on the same FightNo, this is just firstordefault. Idk how perfect the backing data is but if the second one is the "main" boss always, it could be LastOrDefault.

Sorry if this is at all sloppy, it took quite a bit to figure out how to even run this project since it has some hard coded assumptions like game path and configs for the generator